### PR TITLE
Remove premature error flag assignment in ErrorRetry

### DIFF
--- a/utils/services.go
+++ b/utils/services.go
@@ -208,7 +208,6 @@ func SetServiceEndpoints(validServices []Service) {
 // Will retry the fetch request if configured (N-times)
 // If not configured will return the initial error
 func ErrorRetry(sd *ServiceData, endpoint Service, initialErr error) (*http.Response, error) {
-	sd.Error = true
 	currentErr := initialErr
 	// If it errors initially and the user has a configured number of retries
 	// This will attempt to retry to get a new valid response the specified number of times


### PR DESCRIPTION
## Summary
Removed an unnecessary line that was prematurely setting the error flag in the `ErrorRetry` function before retry logic was executed.

## Key Changes
- Removed `sd.Error = true` assignment from the beginning of `ErrorRetry()` function in `utils/services.go`

## Details
The `sd.Error = true` statement was being set immediately upon entering the `ErrorRetry` function, before any retry attempts were made. This could cause the error flag to be set even if subsequent retries succeeded. By removing this line, the error flag will only be set if retries are exhausted or not configured, allowing the retry logic to properly determine the final error state.

https://claude.ai/code/session_01XrfhFBVoNifU77qvc8e5pf